### PR TITLE
Update Startup.cs

### DIFF
--- a/TestProject_ServerSide/Startup.cs
+++ b/TestProject_ServerSide/Startup.cs
@@ -23,9 +23,9 @@ namespace TestProject_ServerSide
         public void ConfigureServices(IServiceCollection services)
         {
             // configuring signalR this way allows for saving large imagedata
-            _ = services.AddSignalR(o => 
+            _ = services.AddSignalR(o => {
                 o.MaximumReceiveMessageSize = long.MaxValue;                
-            );    
+            });    
             _ = services.AddRazorPages();
             _ = services.AddServerSideBlazor();
             _ = services.AddScoped((s) =>

--- a/TestProject_ServerSide/Startup.cs
+++ b/TestProject_ServerSide/Startup.cs
@@ -22,6 +22,10 @@ namespace TestProject_ServerSide
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            // configuring signalR this way allows for saving large imagedata
+            _ = services.AddSignalR(o => 
+                o.MaximumReceiveMessageSize = long.MaxValue;                
+            );    
             _ = services.AddRazorPages();
             _ = services.AddServerSideBlazor();
             _ = services.AddScoped((s) =>


### PR DESCRIPTION
Added a configuration to SignalR to allow larger messages. This way, the Server doesnt fail when trying get Large Image Data.
I have not tested this in your Project yet, but used this to workaround succesfully.